### PR TITLE
#55, #154, #116 - Prompt for layer package or select alternate EGDB/GDB on start

### DIFF
--- a/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
+++ b/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
@@ -32,19 +32,25 @@ namespace ProSymbolEditor
     {
         private bool _schemaExists;
         private string _databaseName;
-
         private string _egdbConnectionString;
 
         public MilitaryOverlayDataModel()
         {
             _schemaExists = false;
+            _databaseName = string.Empty;
+            _egdbConnectionString = string.Empty;
+            EGDBPrefixName = string.Empty;
+        }
+
+        public string EGDBPrefixName
+        {
+            get; set;
         }
 
         Dictionary<string, bool> GetFeatureClassExistsMap(ProSymbolUtilities.SupportedStandardsType standard,
             Geodatabase gdb = null)
         {
-
-            string prefixName = string.Empty;
+            EGDBPrefixName = string.Empty;
             _egdbConnectionString = string.Empty;
 
             if (gdb != null)
@@ -58,7 +64,7 @@ namespace ProSymbolEditor
 
                     if (dbcps != null)
                     {
-                        prefixName = dbcps.Database + "." + dbcps.User + ".";
+                        EGDBPrefixName = dbcps.Database + "." + dbcps.User + ".";
 
                         // Also save this connection string to identify this EGDB later 
                         _egdbConnectionString = ((Datastore)gdb).GetConnectionString();
@@ -71,48 +77,48 @@ namespace ProSymbolEditor
             if (standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
             {
                 // 2525c_b2
-                featureClassExists.Add(prefixName + "Activities", false);
-                featureClassExists.Add(prefixName + "Air", false);
-                featureClassExists.Add(prefixName + "ControlMeasuresAreas", false);
-                featureClassExists.Add(prefixName + "ControlMeasuresLines", false);
-                featureClassExists.Add(prefixName + "ControlMeasuresPoints", false);
-                featureClassExists.Add(prefixName + "Installations", false);
-                featureClassExists.Add(prefixName + "LandEquipment", false);
-                featureClassExists.Add(prefixName + "METOCAreas", false);
-                featureClassExists.Add(prefixName + "METOCLines", false);
-                featureClassExists.Add(prefixName + "METOCPoints", false);
-                featureClassExists.Add(prefixName + "SeaSubsurface", false);
-                featureClassExists.Add(prefixName + "SeaSurface", false);
-                featureClassExists.Add(prefixName + "SIGINT", false);
-                featureClassExists.Add(prefixName + "Space", false);
-                featureClassExists.Add(prefixName + "Units", false);
+                featureClassExists.Add(EGDBPrefixName + "Activities", false);
+                featureClassExists.Add(EGDBPrefixName + "Air", false);
+                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresAreas", false);
+                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresLines", false);
+                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresPoints", false);
+                featureClassExists.Add(EGDBPrefixName + "Installations", false);
+                featureClassExists.Add(EGDBPrefixName + "LandEquipment", false);
+                featureClassExists.Add(EGDBPrefixName + "METOCAreas", false);
+                featureClassExists.Add(EGDBPrefixName + "METOCLines", false);
+                featureClassExists.Add(EGDBPrefixName + "METOCPoints", false);
+                featureClassExists.Add(EGDBPrefixName + "SeaSubsurface", false);
+                featureClassExists.Add(EGDBPrefixName + "SeaSurface", false);
+                featureClassExists.Add(EGDBPrefixName + "SIGINT", false);
+                featureClassExists.Add(EGDBPrefixName + "Space", false);
+                featureClassExists.Add(EGDBPrefixName + "Units", false);
             }
             else
             {
                 // 2525d
-                featureClassExists.Add(prefixName + "Activities", false);
-                featureClassExists.Add(prefixName + "Air", false);
-                featureClassExists.Add(prefixName + "AirMissile", false);
-                featureClassExists.Add(prefixName + "Civilian", false);
-                featureClassExists.Add(prefixName + "ControlMeasuresAreas", false);
-                featureClassExists.Add(prefixName + "ControlMeasuresLines", false);
-                featureClassExists.Add(prefixName + "ControlMeasuresPoints", false);
-                featureClassExists.Add(prefixName + "Cyberspace", false);
-                featureClassExists.Add(prefixName + "Installations", false);
-                featureClassExists.Add(prefixName + "LandEquipment", false);
-                featureClassExists.Add(prefixName + "METOCAreasAtmospheric", false);
-                featureClassExists.Add(prefixName + "METOCAreasOceanographic", false);
-                featureClassExists.Add(prefixName + "METOCLinesAtmospheric", false);
-                featureClassExists.Add(prefixName + "METOCLinesOceanographic", false);
-                featureClassExists.Add(prefixName + "METOCPointsAtmospheric", false);
-                featureClassExists.Add(prefixName + "METOCPointsOceanographic", false);
-                featureClassExists.Add(prefixName + "MineWarfare", false);
-                featureClassExists.Add(prefixName + "SeaSubsurface", false);
-                featureClassExists.Add(prefixName + "SeaSurface", false);
-                featureClassExists.Add(prefixName + "SIGINT", false);
-                featureClassExists.Add(prefixName + "Space", false);
-                featureClassExists.Add(prefixName + "SpaceMissile", false);
-                featureClassExists.Add(prefixName + "Units", false);
+                featureClassExists.Add(EGDBPrefixName + "Activities", false);
+                featureClassExists.Add(EGDBPrefixName + "Air", false);
+                featureClassExists.Add(EGDBPrefixName + "AirMissile", false);
+                featureClassExists.Add(EGDBPrefixName + "Civilian", false);
+                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresAreas", false);
+                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresLines", false);
+                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresPoints", false);
+                featureClassExists.Add(EGDBPrefixName + "Cyberspace", false);
+                featureClassExists.Add(EGDBPrefixName + "Installations", false);
+                featureClassExists.Add(EGDBPrefixName + "LandEquipment", false);
+                featureClassExists.Add(EGDBPrefixName + "METOCAreasAtmospheric", false);
+                featureClassExists.Add(EGDBPrefixName + "METOCAreasOceanographic", false);
+                featureClassExists.Add(EGDBPrefixName + "METOCLinesAtmospheric", false);
+                featureClassExists.Add(EGDBPrefixName + "METOCLinesOceanographic", false);
+                featureClassExists.Add(EGDBPrefixName + "METOCPointsAtmospheric", false);
+                featureClassExists.Add(EGDBPrefixName + "METOCPointsOceanographic", false);
+                featureClassExists.Add(EGDBPrefixName + "MineWarfare", false);
+                featureClassExists.Add(EGDBPrefixName + "SeaSubsurface", false);
+                featureClassExists.Add(EGDBPrefixName + "SeaSurface", false);
+                featureClassExists.Add(EGDBPrefixName + "SIGINT", false);
+                featureClassExists.Add(EGDBPrefixName + "Space", false);
+                featureClassExists.Add(EGDBPrefixName + "SpaceMissile", false);
+                featureClassExists.Add(EGDBPrefixName + "Units", false);
             }
 
             return featureClassExists;
@@ -142,6 +148,14 @@ namespace ProSymbolEditor
             Geodatabase geodatabase = null;
             await QueuedTask.Run(() => geodatabase = (layer.GetTable().GetDatastore() as Geodatabase));
             return geodatabase;
+        }
+
+        public string GetDatasetName()
+        {            
+            if (ProSymbolUtilities.Standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
+                return EGDBPrefixName + "militaryoverlay2525b2";
+            else
+                return EGDBPrefixName + "militaryoverlay2525d";
         }
 
         public async Task<bool> IsGDBAndFeatureClassInActiveView(string featureClassName)
@@ -207,7 +221,7 @@ namespace ProSymbolEditor
 
             await ArcGIS.Desktop.Framework.Threading.Tasks.QueuedTask.Run(() =>
             {
-                string uri = $@"{DatabaseName}\{ProSymbolUtilities.GetDatasetName()}\{featureClassName}";
+                string uri = $@"{DatabaseName}\{GetDatasetName()}\{featureClassName}";
                 Item currentItem = ItemFactory.Instance.Create(uri);
                 if (LayerFactory.Instance.CanCreateLayerFrom(currentItem))
                 {
@@ -258,6 +272,112 @@ namespace ProSymbolEditor
             return await ShouldAddInBeEnabledAsync(ProSymbolUtilities.Standard);
         }
 
+        public async Task<bool> GDBContainsSchema(GDBProjectItem gdbProjectItem, 
+            ProSymbolUtilities.SupportedStandardsType standard)
+        {
+            bool isSchemaComplete = await 
+                ArcGIS.Desktop.Framework.Threading.Tasks.QueuedTask.Run<bool>(() =>
+            {
+                if (gdbProjectItem == null)
+                    return false;
+
+                using (Datastore datastore = gdbProjectItem.GetDatastore())
+                {
+                    // Unsupported datastores (non File GDB and non Enterprise GDB) will be of type UnknownDatastore
+                    if (datastore is UnknownDatastore)
+                        return false; 
+
+                    Geodatabase geodatabase = datastore as Geodatabase;
+                    if (geodatabase == null)
+                        return false;
+
+                    // Set up Fields to check
+                    List<string> fieldsToCheck = new List<string>();
+
+                    if (standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
+                    {
+                        fieldsToCheck.Add("extendedfunctioncode");
+                    }
+                    else
+                    {   // 2525d
+                        fieldsToCheck.Add("symbolset");
+                        fieldsToCheck.Add("symbolentity");
+                    }
+
+                    // Reset schema data model exists to false for each feature class
+                    Dictionary<string, bool> featureClassExists = GetFeatureClassExistsMap(standard, geodatabase);
+
+                    IReadOnlyList<FeatureClassDefinition> featureClassDefinitions = geodatabase.GetDefinitions<FeatureClassDefinition>();
+
+                    bool stopLooking = false;
+                    foreach (FeatureClassDefinition featureClassDefinition in featureClassDefinitions)
+                    {
+                        // Stop looking after the first feature class not found
+                        if (stopLooking)
+                        {
+                            return false;
+                        }
+
+                        string featureClassName = featureClassDefinition.GetName();
+
+                        if (featureClassExists.ContainsKey(featureClassName))
+                        {
+                            // Feature Class Exists. Check for fields
+                            bool fieldsExist = true;
+                            foreach (string fieldName in fieldsToCheck)
+                            {
+                                IEnumerable<Field> foundFields = featureClassDefinition.GetFields().Where(x => x.Name == fieldName);
+
+                                if (foundFields.Count() < 1)
+                                {
+                                    fieldsExist = false;
+                                    return false;
+                                }
+                            }
+
+                            featureClassExists[featureClassName] = fieldsExist;
+                        }
+                        else
+                        {
+                            // Key doesn't exist, so ignore
+                        }
+                    }
+
+                    foreach (KeyValuePair<string, bool> pair in featureClassExists)
+                    {
+                        if (pair.Value == false)
+                        {
+                            return false;
+                        }
+                    }
+
+                    // If here, schema is complete
+                    // Save geodatabase path to use as the selected database
+                    _databaseName = gdbProjectItem.Path;
+                    _schemaExists = true;
+
+                    return true;
+                }
+            });
+
+            return isSchemaComplete;
+        }
+
+        public async Task<bool> ShouldAddInBeEnabledAsync(string gdbPath, ProSymbolUtilities.SupportedStandardsType standard)
+        {
+            bool gdbEnabledWithStanadard = false;
+
+            await ArcGIS.Desktop.Framework.Threading.Tasks.QueuedTask.Run(async () =>
+            {
+                var currentItem = ItemFactory.Instance.Create(gdbPath);
+
+                if (currentItem is GDBProjectItem)
+                    gdbEnabledWithStanadard = await GDBContainsSchema(currentItem as GDBProjectItem, standard);
+            });
+
+            return gdbEnabledWithStanadard;
+        }
+
         public async Task<bool> ShouldAddInBeEnabledAsync(ProSymbolUtilities.SupportedStandardsType standard)
         {
             _schemaExists = false;
@@ -273,97 +393,112 @@ namespace ProSymbolEditor
             try
             {
                 IEnumerable<GDBProjectItem> gdbProjectItems = Project.Current.GetItems<GDBProjectItem>();
-                await ArcGIS.Desktop.Framework.Threading.Tasks.QueuedTask.Run(() =>
+
+                foreach (GDBProjectItem gdbProjectItem in gdbProjectItems)
                 {
-                    foreach (GDBProjectItem gdbProjectItem in gdbProjectItems)
+                    if (gdbProjectItem.Name == "map.gdb") // ignore the project Map GDB
+                        continue;
+
+                    bool isSchemaComplete = await GDBContainsSchema(gdbProjectItem, standard);
+
+                    // if schema is there/complete then done
+                    if (isSchemaComplete)
                     {
-                        if (gdbProjectItem.Name == "map.gdb") // ignore the project Map GDB
-                            continue;
-
-                        using (Datastore datastore = gdbProjectItem.GetDatastore())
-                        {
-                            //Unsupported datastores (non File GDB and non Enterprise GDB) will be of type UnknownDatastore
-                            if (datastore is UnknownDatastore)
-                                continue;
-
-                            Geodatabase geodatabase = datastore as Geodatabase;
-                            if (geodatabase == null)
-                                continue;
-
-                            //Set up Fields to check
-                            List<string> fieldsToCheck = new List<string>();
-
-                            if (standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
-                            {
-                                fieldsToCheck.Add("extendedfunctioncode");
-                            }
-                            else
-                            {   // 2525d
-                                fieldsToCheck.Add("symbolset");
-                                fieldsToCheck.Add("symbolentity");
-                            }
-
-                            // Reset schema data model exists to false for each feature class
-                            Dictionary<string, bool> featureClassExists = GetFeatureClassExistsMap(standard, geodatabase);
-
-                            IReadOnlyList<FeatureClassDefinition> featureClassDefinitions = geodatabase.GetDefinitions<FeatureClassDefinition>();
-
-                            bool stopLooking = false;
-                            foreach(FeatureClassDefinition featureClassDefinition in featureClassDefinitions)
-                            {
-                                // stop looking after the first feature class not found
-                                if (stopLooking)
-                                    break;
-
-                                string featureClassName = featureClassDefinition.GetName();
-
-                                if (featureClassExists.ContainsKey(featureClassName))
-                                {
-                                    //Feature Class Exists!  Check for fields
-                                    bool fieldsExist = true;
-                                    foreach(string fieldName in fieldsToCheck)
-                                    {
-                                        IEnumerable<Field> foundFields = featureClassDefinition.GetFields().Where(x => x.Name == fieldName);
-
-                                        if (foundFields.Count() < 1)
-                                        {
-                                            fieldsExist = false;
-                                            stopLooking = true;
-                                            break;
-                                        }
-                                    }
-
-                                    featureClassExists[featureClassName] = fieldsExist;
-                                }
-                                else
-                                {
-                                    //Key doesn't exist, so ignore
-                                }
-                            }
-
-                            bool isSchemaComplete = true;
-       
-                            foreach (KeyValuePair<string, bool> pair in featureClassExists)
-                            {
-                                if (pair.Value == false)
-                                {
-                                    isSchemaComplete =  false;
-                                    break;
-                                }
-                            }
-
-                            //Check if schema is all there
-                            if (isSchemaComplete)
-                            {
-                                //Save geodatabase path to use as the selected database
-                                _databaseName = gdbProjectItem.Path;
-                                _schemaExists = true;
-
-                                break;
-                            }
-                        }
+                        break;
                     }
-                });
+                }
+
+                    //await ArcGIS.Desktop.Framework.Threading.Tasks.QueuedTask.Run(() =>
+                    //{
+                    //    foreach (GDBProjectItem gdbProjectItem in gdbProjectItems)
+                    //    {
+                    //        if (gdbProjectItem.Name == "map.gdb") // ignore the project Map GDB
+                    //            continue;
+
+                    //        using (Datastore datastore = gdbProjectItem.GetDatastore())
+                    //        {
+                    //            //Unsupported datastores (non File GDB and non Enterprise GDB) will be of type UnknownDatastore
+                    //            if (datastore is UnknownDatastore)
+                    //                continue;
+
+                    //            Geodatabase geodatabase = datastore as Geodatabase;
+                    //            if (geodatabase == null)
+                    //                continue;
+
+                    //            //Set up Fields to check
+                    //            List<string> fieldsToCheck = new List<string>();
+
+                    //            if (standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
+                    //            {
+                    //                fieldsToCheck.Add("extendedfunctioncode");
+                    //            }
+                    //            else
+                    //            {   // 2525d
+                    //                fieldsToCheck.Add("symbolset");
+                    //                fieldsToCheck.Add("symbolentity");
+                    //            }
+
+                    //            // Reset schema data model exists to false for each feature class
+                    //            Dictionary<string, bool> featureClassExists = GetFeatureClassExistsMap(standard, geodatabase);
+
+                    //            IReadOnlyList<FeatureClassDefinition> featureClassDefinitions = geodatabase.GetDefinitions<FeatureClassDefinition>();
+
+                    //            bool stopLooking = false;
+                    //            foreach(FeatureClassDefinition featureClassDefinition in featureClassDefinitions)
+                    //            {
+                    //                // stop looking after the first feature class not found
+                    //                if (stopLooking)
+                    //                    break;
+
+                    //                string featureClassName = featureClassDefinition.GetName();
+
+                    //                if (featureClassExists.ContainsKey(featureClassName))
+                    //                {
+                    //                    //Feature Class Exists!  Check for fields
+                    //                    bool fieldsExist = true;
+                    //                    foreach(string fieldName in fieldsToCheck)
+                    //                    {
+                    //                        IEnumerable<Field> foundFields = featureClassDefinition.GetFields().Where(x => x.Name == fieldName);
+
+                    //                        if (foundFields.Count() < 1)
+                    //                        {
+                    //                            fieldsExist = false;
+                    //                            stopLooking = true;
+                    //                            break;
+                    //                        }
+                    //                    }
+
+                    //                    featureClassExists[featureClassName] = fieldsExist;
+                    //                }
+                    //                else
+                    //                {
+                    //                    //Key doesn't exist, so ignore
+                    //                }
+                    //            }
+
+                    //            bool isSchemaComplete = true;
+
+                    //            foreach (KeyValuePair<string, bool> pair in featureClassExists)
+                    //            {
+                    //                if (pair.Value == false)
+                    //                {
+                    //                    isSchemaComplete =  false;
+                    //                    break;
+                    //                }
+                    //            }
+
+                    //            //Check if schema is all there
+                    //            if (isSchemaComplete)
+                    //            {
+                    //                //Save geodatabase path to use as the selected database
+                    //                _databaseName = gdbProjectItem.Path;
+                    //                _schemaExists = true;
+
+                    //                break;
+                    //            }
+                    //        }
+                    //    }
+                    //});
             }
             catch (Exception exception)
             {

--- a/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
+++ b/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
@@ -306,14 +306,19 @@ namespace ProSymbolEditor
                         {
                             // Feature Class Exists. Check for fields
                             bool fieldsExist = true;
-                            foreach (string fieldName in fieldsToCheck)
-                            {
-                                IEnumerable<Field> foundFields = featureClassDefinition.GetFields().Where(x => x.Name == fieldName);
 
-                                if (foundFields.Count() < 1)
+                            // Don't do this for remote databases (too slow)
+                            if (geodatabase.GetGeodatabaseType() != GeodatabaseType.RemoteDatabase)
+                            {
+                                foreach (string fieldName in fieldsToCheck)
                                 {
-                                    fieldsExist = false;
-                                    return false;
+                                    IEnumerable<Field> foundFields = featureClassDefinition.GetFields().Where(x => x.Name == fieldName);
+
+                                    if (foundFields.Count() < 1)
+                                    {
+                                        fieldsExist = false;
+                                        return false;
+                                    }
                                 }
                             }
 

--- a/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
+++ b/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
@@ -25,6 +25,7 @@ using ArcGIS.Desktop.Catalog;
 using ArcGIS.Desktop.Core;
 using ArcGIS.Desktop.Mapping;
 using ArcGIS.Desktop.Framework.Threading.Tasks;
+using ArcGIS.Core.Geometry;
 
 namespace ProSymbolEditor
 {
@@ -40,6 +41,8 @@ namespace ProSymbolEditor
             _databaseName = string.Empty;
             _egdbConnectionString = string.Empty;
             EGDBPrefixName = string.Empty;
+
+            initializeSymbolSetToFeatureClassMapping();
         }
 
         public string EGDBPrefixName
@@ -74,51 +77,18 @@ namespace ProSymbolEditor
 
             Dictionary<string, bool> featureClassExists = new Dictionary<string, bool>();
 
+            List<SymbolSetMapping> symbolSetMapping = null;
             if (standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
-            {
-                // 2525c_b2
-                featureClassExists.Add(EGDBPrefixName + "Activities", false);
-                featureClassExists.Add(EGDBPrefixName + "Air", false);
-                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresAreas", false);
-                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresLines", false);
-                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresPoints", false);
-                featureClassExists.Add(EGDBPrefixName + "Installations", false);
-                featureClassExists.Add(EGDBPrefixName + "LandEquipment", false);
-                featureClassExists.Add(EGDBPrefixName + "METOCAreas", false);
-                featureClassExists.Add(EGDBPrefixName + "METOCLines", false);
-                featureClassExists.Add(EGDBPrefixName + "METOCPoints", false);
-                featureClassExists.Add(EGDBPrefixName + "SeaSubsurface", false);
-                featureClassExists.Add(EGDBPrefixName + "SeaSurface", false);
-                featureClassExists.Add(EGDBPrefixName + "SIGINT", false);
-                featureClassExists.Add(EGDBPrefixName + "Space", false);
-                featureClassExists.Add(EGDBPrefixName + "Units", false);
-            }
+                symbolSetMapping = _symbolSetMapping2525C;
             else
+                symbolSetMapping = _symbolSetMapping2525D;
+
+            foreach (SymbolSetMapping mapping in symbolSetMapping)
             {
-                // 2525d
-                featureClassExists.Add(EGDBPrefixName + "Activities", false);
-                featureClassExists.Add(EGDBPrefixName + "Air", false);
-                featureClassExists.Add(EGDBPrefixName + "AirMissile", false);
-                featureClassExists.Add(EGDBPrefixName + "Civilian", false);
-                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresAreas", false);
-                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresLines", false);
-                featureClassExists.Add(EGDBPrefixName + "ControlMeasuresPoints", false);
-                featureClassExists.Add(EGDBPrefixName + "Cyberspace", false);
-                featureClassExists.Add(EGDBPrefixName + "Installations", false);
-                featureClassExists.Add(EGDBPrefixName + "LandEquipment", false);
-                featureClassExists.Add(EGDBPrefixName + "METOCAreasAtmospheric", false);
-                featureClassExists.Add(EGDBPrefixName + "METOCAreasOceanographic", false);
-                featureClassExists.Add(EGDBPrefixName + "METOCLinesAtmospheric", false);
-                featureClassExists.Add(EGDBPrefixName + "METOCLinesOceanographic", false);
-                featureClassExists.Add(EGDBPrefixName + "METOCPointsAtmospheric", false);
-                featureClassExists.Add(EGDBPrefixName + "METOCPointsOceanographic", false);
-                featureClassExists.Add(EGDBPrefixName + "MineWarfare", false);
-                featureClassExists.Add(EGDBPrefixName + "SeaSubsurface", false);
-                featureClassExists.Add(EGDBPrefixName + "SeaSurface", false);
-                featureClassExists.Add(EGDBPrefixName + "SIGINT", false);
-                featureClassExists.Add(EGDBPrefixName + "Space", false);
-                featureClassExists.Add(EGDBPrefixName + "SpaceMissile", false);
-                featureClassExists.Add(EGDBPrefixName + "Units", false);
+                string featureClassName = EGDBPrefixName + mapping.FeatureClassName;
+
+                if (!featureClassExists.ContainsKey(featureClassName))
+                    featureClassExists.Add(featureClassName, false);
             }
 
             return featureClassExists;
@@ -506,6 +476,86 @@ namespace ProSymbolEditor
             }
 
             return SchemaExists;
+        }
+
+        public static List<SymbolSetMapping> SymbolSetToFeatureClassMapping2525D
+        {
+            get
+            {
+                if (_symbolSetMapping2525D == null)
+                    initializeSymbolSetToFeatureClassMapping();
+
+                return _symbolSetMapping2525D;
+            }
+        }
+        private static List<SymbolSetMapping> _symbolSetMapping2525D = null;
+
+        public static List<SymbolSetMapping> SymbolSetToFeatureClassMapping2525C
+        {
+            get
+            {
+                if (_symbolSetMapping2525C == null)
+                    initializeSymbolSetToFeatureClassMapping();
+
+                return _symbolSetMapping2525C;
+            }
+        }
+        private static List<SymbolSetMapping> _symbolSetMapping2525C = null;
+
+        private static void initializeSymbolSetToFeatureClassMapping()
+        {
+            // IMPORTANT: this is the single list of 
+            // 1. What feature classes are part of the required schema
+            // 2. What symbols map to those feature classes based on feature geometry and 
+            //    other identifying attribute (symbol set for 2525D, SIDC for 2525C)
+
+            // 2525D 
+            _symbolSetMapping2525D = new List<SymbolSetMapping>();
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("Air", GeometryType.Point, "01"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("AirMissile", GeometryType.Point, "02"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("Space", GeometryType.Point, "05"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("SpaceMissile", GeometryType.Point, "06"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("Units", GeometryType.Point, "10"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("Civilian", GeometryType.Point, "11"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("LandEquipment", GeometryType.Point, "15"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("Installations", GeometryType.Point, "20"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("ControlMeasuresPoints", GeometryType.Point, "25"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("ControlMeasuresLines", GeometryType.Polyline, "25"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("ControlMeasuresAreas", GeometryType.Polygon, "25"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("SeaSurface", GeometryType.Point, "30"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("SeaSubsurface", GeometryType.Point, "35"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("MineWarfare", GeometryType.Point, "36"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("Activities", GeometryType.Point, "40"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("METOCPointsAtmospheric", GeometryType.Point, "45"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("METOCLinesAtmospheric", GeometryType.Polyline, "45"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("METOCAreasAtmospheric", GeometryType.Polygon, "45"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("METOCPointsOceanographic", GeometryType.Point, "46"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("METOCLinesOceanographic", GeometryType.Polyline, "46"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("METOCAreasOceanographic", GeometryType.Polygon, "46"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "50"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "51"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "52"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "53"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "54"));
+            _symbolSetMapping2525D.Add(new SymbolSetMapping("Cyberspace", GeometryType.Point, "60"));
+
+            // 2525C
+            _symbolSetMapping2525C = new List<SymbolSetMapping>();
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("Air", GeometryType.Point, "^[S].[A].{7,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("Space", GeometryType.Point, "^[S].[P].{7,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("LandEquipment", GeometryType.Point, "^[S].[G].[E].{5,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("Installations", GeometryType.Point, "^[S].[G].[I].{5,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("Units", GeometryType.Point, "^[S].[GF].{7,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("ControlMeasuresPoints", GeometryType.Point, "^[G].{9,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("ControlMeasuresLines", GeometryType.Polyline, "^[G].{9,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("ControlMeasuresAreas", GeometryType.Polygon, "^[G].{9,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("SeaSurface", GeometryType.Point, "^[S].[S].{7,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("SeaSubsurface", GeometryType.Point, "^[S].[U].{7,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("Activities", GeometryType.Point, "^[OE].{9,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("METOCPoints", GeometryType.Point, "^[W].{9,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("METOCLines", GeometryType.Polyline, "^[W].{9,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("METOCAreas", GeometryType.Polygon, "^[W].{9,}"));
+            _symbolSetMapping2525C.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "^[I].{9,}"));
         }
     }
 }

--- a/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
+++ b/source/ProSymbolEditor/Models/MilitaryOverlayDataModel.cs
@@ -254,6 +254,33 @@ namespace ProSymbolEditor
             return await ShouldAddInBeEnabledAsync(ProSymbolUtilities.Standard);
         }
 
+        public async Task<bool> GDBContainsMilitaryOverlay(GDBProjectItem gdbProjectItem)
+        {
+            if (gdbProjectItem == null)
+                return false;
+
+            bool gdbContainsMilitaryOverlay = await
+                ArcGIS.Desktop.Framework.Threading.Tasks.QueuedTask.Run<bool>(() => 
+            {
+                using (Datastore datastore = gdbProjectItem.GetDatastore())
+                {
+                    // Unsupported datastores (non File GDB and non Enterprise GDB) will be of type UnknownDatastore
+                    if (datastore is UnknownDatastore)
+                        return false;
+
+                    Geodatabase geodatabase = datastore as Geodatabase;
+                    if (geodatabase == null)
+                        return false;
+
+                    var defs = geodatabase.GetDefinitions<FeatureDatasetDefinition>().Select(fd => fd.GetName().StartsWith("militaryoverlay")).ToList(); ;
+
+                    return (defs.Count > 0);
+                }
+            });
+
+            return gdbContainsMilitaryOverlay;
+        }
+
         public async Task<bool> GDBContainsSchema(GDBProjectItem gdbProjectItem, 
             ProSymbolUtilities.SupportedStandardsType standard)
         {

--- a/source/ProSymbolEditor/Models/SymbolSetMappings.cs
+++ b/source/ProSymbolEditor/Models/SymbolSetMappings.cs
@@ -21,65 +21,24 @@ namespace ProSymbolEditor
 {
     public class SymbolSetMappings
     {
-        private List<SymbolSetMapping> _symbolSetMappings2525D;
-        private List<SymbolSetMapping> _symbolSetMappings2525C;
-
-        public List<SymbolSetMapping> SymbolsDictionaryMapping
+        private List<SymbolSetMapping> SymbolSetMappings2525D 
         {
             get
             {
-                return _symbolSetMappings2525D;
+                return MilitaryOverlayDataModel.SymbolSetToFeatureClassMapping2525D;
+            }
+        }
+
+        private List<SymbolSetMapping> SymbolSetMappings2525C
+        {
+            get
+            {
+                return MilitaryOverlayDataModel.SymbolSetToFeatureClassMapping2525C;
             }
         }
 
         public SymbolSetMappings()
         {
-            _symbolSetMappings2525D = new List<SymbolSetMapping>();
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("Unknown", GeometryType.Unknown, "00"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("Air", GeometryType.Point, "01"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("AirMissile", GeometryType.Point, "02"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("Space", GeometryType.Point, "05"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("SpaceMissile", GeometryType.Point, "06"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("Units", GeometryType.Point, "10"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("Civilian", GeometryType.Point, "11"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("LandEquipment", GeometryType.Point, "15"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("Installations", GeometryType.Point, "20"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("ControlMeasuresPoints", GeometryType.Point, "25"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("ControlMeasuresLines", GeometryType.Polyline, "25"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("ControlMeasuresAreas", GeometryType.Polygon, "25"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("SeaSurface", GeometryType.Point, "30"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("SeaSubsurface", GeometryType.Point, "35"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("MineWarfare", GeometryType.Point, "36"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("Activities", GeometryType.Point, "40"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("METOCPointsAtmospheric", GeometryType.Point, "45"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("METOCLinesAtmospheric", GeometryType.Polyline, "45"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("METOCAreasAtmospheric", GeometryType.Polygon, "45"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("METOCPointsOceanographic", GeometryType.Point, "46"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("METOCLinesOceanographic", GeometryType.Polyline, "46"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("METOCAreasOceanographic", GeometryType.Polygon, "46"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "50"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "51"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "52"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "53"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "54"));
-            _symbolSetMappings2525D.Add(new SymbolSetMapping("Cyberspace", GeometryType.Point, "60"));
-
-            _symbolSetMappings2525C = new List<SymbolSetMapping>();
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("Air", GeometryType.Point, "^[S].[A].{7,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("Space", GeometryType.Point, "^[S].[P].{7,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("LandEquipment", GeometryType.Point, "^[S].[G].[E].{5,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("Installations", GeometryType.Point, "^[S].[G].[I].{5,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("Units", GeometryType.Point, "^[S].[GF].{7,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("ControlMeasuresPoints", GeometryType.Point, "^[G].{9,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("ControlMeasuresLines", GeometryType.Polyline, "^[G].{9,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("ControlMeasuresAreas", GeometryType.Polygon, "^[G].{9,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("SeaSurface", GeometryType.Point, "^[S].[S].{7,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("SeaSubsurface", GeometryType.Point, "^[S].[U].{7,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("Activities", GeometryType.Point, "^[OE].{9,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("METOCPoints", GeometryType.Point, "^[W].{9,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("METOCLines", GeometryType.Polyline, "^[W].{9,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("METOCAreas", GeometryType.Polygon, "^[W].{9,}"));
-            _symbolSetMappings2525C.Add(new SymbolSetMapping("SIGINT", GeometryType.Point, "^[I].{9,}"));
         }
 
         public string GetFeatureClassFromSymbolSet(string symbolSet, GeometryType geometryType)
@@ -87,7 +46,7 @@ namespace ProSymbolEditor
             if (string.IsNullOrEmpty(symbolSet))
                 return "Units";
 
-            foreach (SymbolSetMapping mapping in _symbolSetMappings2525D)
+            foreach (SymbolSetMapping mapping in SymbolSetMappings2525D)
             {
                 if ((mapping.SymbolSetOrRegex == symbolSet) && (mapping.GeometryType == geometryType))
                 {
@@ -102,7 +61,7 @@ namespace ProSymbolEditor
             if (string.IsNullOrEmpty(extendedFunctionCode))
                 return "Units";
 
-            foreach (SymbolSetMapping mapping in _symbolSetMappings2525C)
+            foreach (SymbolSetMapping mapping in SymbolSetMappings2525C)
             {
                 if (System.Text.RegularExpressions.Regex.IsMatch(extendedFunctionCode, mapping.SymbolSetOrRegex) &&
                                 (mapping.GeometryType == geometryType))

--- a/source/ProSymbolEditor/SettingsWindow.xaml
+++ b/source/ProSymbolEditor/SettingsWindow.xaml
@@ -9,27 +9,28 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Title="Application Settings"
     Width="300"
-    Height="300"
+    Height="200"
     ResizeMode="NoResize"
     WindowStartupLocation="CenterOwner"
     WindowState="Normal"
     mc:Ignorable="d">
-  <controls:ProWindow.Resources>
-  <ResourceDictionary>
-    <ResourceDictionary.MergedDictionaries>
-     <extensions:DesignOnlyResourceDictionary Source="pack://application:,,,/ArcGIS.Desktop.Framework;component\Themes\Default.xaml"/>
+    <controls:ProWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <extensions:DesignOnlyResourceDictionary Source="pack://application:,,,/ArcGIS.Desktop.Framework;component\Themes\Default.xaml"/>
             </ResourceDictionary.MergedDictionaries>
-      </ResourceDictionary>
- </controls:ProWindow.Resources>
+        </ResourceDictionary>
+    </controls:ProWindow.Resources>
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="*" />
+            <RowDefinition Height="50*" />
+            <RowDefinition Height="50*" />
+            <RowDefinition Height="40*" />
         </Grid.RowDefinitions>
 
         <StackPanel
             Grid.Row="0"
-            Margin="5,5,5,5"
+            Margin="5,5,5,0"
             VerticalAlignment="Top">
             <Label Content="Default _Symbology Standard:"  />
             <WrapPanel>
@@ -45,24 +46,43 @@
                     IsChecked="{Binding Path=Checked2525C_B2, Mode=TwoWay}" />
             </WrapPanel>
         </StackPanel>
+        <StackPanel Grid.Row="1" Margin="5,5,5,0">
+            <Label Content="Military Overlay _Database:"  />
+            <WrapPanel>
+                <TextBox x:Name="tbDefaultDatabase" Width="233" Text="{Binding Path=DefaultDatabase, Mode=TwoWay}" 
+                         IsEnabled="True" IsReadOnly="True" />
+                <Button x:Name="buttonChangeDB" Width="50"
+                        IsEnabled="{Binding Path=IsSelectDBEnabled, Mode=TwoWay}" 
+                Height="{Binding Height, ElementName=tbDefaultDatabase}"
+                        Margin="{Binding Margin, ElementName=tbDefaultDatabase}"
+                        HorizontalAlignment="Right"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center"
+                        Foreground="{DynamicResource Esri_TextControlBrush}" 
+                        Background="{Binding Backgound, ElementName=tbDefaultDatabase}"
+                        Command="{Binding ClearSearchTextCommand}"
+                        Content="Select" Click="Button_Click" />
+            </WrapPanel>
+        </StackPanel>
+
         <StackPanel
-            Grid.Row="1"
+            Grid.Row="2"
             Margin="5,5,5,5"
             HorizontalAlignment="Center"
             VerticalAlignment="Bottom"
-            Orientation="Horizontal">
+            Orientation="Horizontal" Height="24" Width="160">
             <Button
                 x:Name="ok"
                 Width="70"
                 Margin="10,0,0,0"
                 Click="OkClick"
-                Content="OK"
+                Content="_OK"
                 Style="{DynamicResource Esri_SimpleButton}"
                 IsDefault="True" />
             <Button
                 Width="70"
                 Margin="10,0,0,0"
-                Content="Cancel"
+                Content="_Cancel"
                 Style="{DynamicResource Esri_SimpleButton}"
                 IsCancel="True" />
         </StackPanel>

--- a/source/ProSymbolEditor/SettingsWindow.xaml
+++ b/source/ProSymbolEditor/SettingsWindow.xaml
@@ -27,26 +27,7 @@
             <RowDefinition Height="50*" />
             <RowDefinition Height="40*" />
         </Grid.RowDefinitions>
-
-        <StackPanel
-            Grid.Row="0"
-            Margin="5,5,5,0"
-            VerticalAlignment="Top">
-            <Label Content="Default _Symbology Standard:"  />
-            <WrapPanel>
-                <RadioButton
-                    Margin="3"
-                    Content="MIL-STD-2525D"
-                    GroupName="standardgroup"
-                    IsChecked="{Binding Path=Checked2525D, Mode=TwoWay}" />
-                <RadioButton
-                    Margin="3"
-                    Content="MIL-STD-2525B Change 2"
-                    GroupName="standardgroup"
-                    IsChecked="{Binding Path=Checked2525C_B2, Mode=TwoWay}" />
-            </WrapPanel>
-        </StackPanel>
-        <StackPanel Grid.Row="1" Margin="5,5,5,0">
+        <StackPanel Grid.Row="0" Margin="5,5,5,0">
             <Label Content="Military Overlay _Database:"  />
             <WrapPanel>
                 <TextBox x:Name="tbDefaultDatabase" Width="233" Text="{Binding Path=DefaultDatabase, Mode=TwoWay}" 
@@ -61,10 +42,25 @@
                         Foreground="{DynamicResource Esri_TextControlBrush}" 
                         Background="{Binding Backgound, ElementName=tbDefaultDatabase}"
                         Command="{Binding ClearSearchTextCommand}"
-                        Content="Select" Click="Button_Click" />
+                        Content="Browse" Click="Button_Click" />
             </WrapPanel>
         </StackPanel>
-
+        <StackPanel
+            Grid.Row="1"
+            Margin="5,5,5,0"
+            VerticalAlignment="Top">
+            <Label Content="Military Symbology _Standard:"  />
+            <ComboBox 
+                IsReadOnly="True" IsEditable="False" IsEnabled="{Binding Path=IsSettingsNotReadOnly}" 
+                ItemContainerStyle="{DynamicResource Esri_HighlightListBoxItem}"
+                ItemsSource="{Binding SymbologyStandards, UpdateSourceTrigger=PropertyChanged}"
+                SelectedItem="{Binding SelectedSymbologyStandard, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                >
+                <ComboBox.Style>
+                    <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}"/>
+                </ComboBox.Style>
+            </ComboBox>    
+        </StackPanel>
         <StackPanel
             Grid.Row="2"
             Margin="5,5,5,5"

--- a/source/ProSymbolEditor/SettingsWindow.xaml
+++ b/source/ProSymbolEditor/SettingsWindow.xaml
@@ -50,7 +50,7 @@
             Margin="5,5,5,0"
             VerticalAlignment="Top">
             <Label Content="Military Symbology _Standard:"  />
-            <ComboBox 
+            <ComboBox x:Name="cbStandard"
                 IsReadOnly="True" IsEditable="False" IsEnabled="{Binding Path=IsSettingsNotReadOnly}" 
                 ItemContainerStyle="{DynamicResource Esri_HighlightListBoxItem}"
                 ItemsSource="{Binding SymbologyStandards, UpdateSourceTrigger=PropertyChanged}"

--- a/source/ProSymbolEditor/SettingsWindow.xaml.cs
+++ b/source/ProSymbolEditor/SettingsWindow.xaml.cs
@@ -127,6 +127,9 @@ namespace ProSymbolEditor
             // or give user the option of selecting workspace:
             string selectedGDB = ProSymbolUtilities.BrowseItem(ArcGIS.Desktop.Catalog.ItemFilters.geodatabases);
 
+            if (string.IsNullOrEmpty(selectedGDB))
+                return;
+
             if (DefaultDatabase != selectedGDB)
             {
                 DefaultDatabaseChanged = true;

--- a/source/ProSymbolEditor/SettingsWindow.xaml.cs
+++ b/source/ProSymbolEditor/SettingsWindow.xaml.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
@@ -36,53 +37,37 @@ namespace ProSymbolEditor
     /// </summary>
     public partial class SettingsWindow : ArcGIS.Desktop.Framework.Controls.ProWindow, INotifyPropertyChanged
     {
+        public bool IsSettingsReadOnly
+        {
+            get; set;
+        }
+
+        public bool IsSettingsNotReadOnly
+        {
+            get { return !IsSettingsReadOnly; }
+        }
 
         public ProSymbolUtilities.SupportedStandardsType Standard
         {
+            get; set;
+        }
+
+        public ObservableCollection<string> SymbologyStandards { get; set; }
+
+        public string SelectedSymbologyStandard
+        {
             get
             {
-                ProSymbolUtilities.SupportedStandardsType standard;
-
-                if (Checked2525C_B2 == true)
-                    standard = ProSymbolUtilities.SupportedStandardsType.mil2525c_b2;
-                else
-                    standard = ProSymbolUtilities.SupportedStandardsType.mil2525d;
-
-                return standard;
+                return ProSymbolUtilities.GetStandardLabel(Standard);
             }
             set
             {
-                ProSymbolUtilities.SupportedStandardsType standard = value;
+                string standardString = value;
 
-                if (standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
-                    Checked2525C_B2 = true;
-                else
-                    Checked2525D = true;
+                Standard = ProSymbolUtilities.GetStandardFromLabel(standardString);
             }
         }
 
-        // Radio Button binding special binding case:
-        public bool Checked2525D
-        {
-            get { return _checked2525D; }
-            set
-            {
-                _checked2525D = value;
-                _checked2525C_B2 = !_checked2525D;
-            }
-        }
-        bool _checked2525D;
-
-        public bool Checked2525C_B2
-        {
-            get { return _checked2525C_B2; }
-            set
-            {
-                _checked2525C_B2 = value;
-                _checked2525D = !_checked2525C_B2;
-            }
-        }
-        bool _checked2525C_B2;
 
         public bool IsSelectDBEnabled
         {
@@ -91,8 +76,19 @@ namespace ProSymbolEditor
 
         public string DefaultDatabase
         {
-            get; set;
+            get
+            {
+                if (string.IsNullOrEmpty(_defaultDatabase))
+                    return "{default}";
+                else
+                    return _defaultDatabase;
+            }
+            set
+            {
+                _defaultDatabase = value;
+            }
         }
+        private string _defaultDatabase;
 
         public bool DefaultDatabaseChanged
         {
@@ -106,8 +102,13 @@ namespace ProSymbolEditor
 
             this.DataContext = this;
 
-            this.DefaultDatabaseChanged = false;
-            this.IsSelectDBEnabled = false;
+            IsSettingsReadOnly = false;
+            DefaultDatabaseChanged = false;
+            IsSelectDBEnabled = false;
+
+            SymbologyStandards = new ObservableCollection<string>();
+            SymbologyStandards.Add(ProSymbolUtilities.GetStandardLabel(ProSymbolUtilities.SupportedStandardsType.mil2525c_b2));
+            SymbologyStandards.Add(ProSymbolUtilities.GetStandardLabel(ProSymbolUtilities.SupportedStandardsType.mil2525d));
         }
 
         public void ShowDialog(Window owner)
@@ -133,7 +134,6 @@ namespace ProSymbolEditor
 
                 RaisePropertyChanged("DefaultDatabase");
             }
-
         }
 
         private void RaisePropertyChanged(string propertyName)

--- a/source/ProSymbolEditor/SettingsWindow.xaml.cs
+++ b/source/ProSymbolEditor/SettingsWindow.xaml.cs
@@ -13,9 +13,10 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  ******************************************************************************/
- 
+
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -33,8 +34,32 @@ namespace ProSymbolEditor
     /// <summary>
     /// Interaction logic for SettingsWindow.xaml
     /// </summary>
-    public partial class SettingsWindow : ArcGIS.Desktop.Framework.Controls.ProWindow
+    public partial class SettingsWindow : ArcGIS.Desktop.Framework.Controls.ProWindow, INotifyPropertyChanged
     {
+
+        public ProSymbolUtilities.SupportedStandardsType Standard
+        {
+            get
+            {
+                ProSymbolUtilities.SupportedStandardsType standard;
+
+                if (Checked2525C_B2 == true)
+                    standard = ProSymbolUtilities.SupportedStandardsType.mil2525c_b2;
+                else
+                    standard = ProSymbolUtilities.SupportedStandardsType.mil2525d;
+
+                return standard;
+            }
+            set
+            {
+                ProSymbolUtilities.SupportedStandardsType standard = value;
+
+                if (standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
+                    Checked2525C_B2 = true;
+                else
+                    Checked2525D = true;
+            }
+        }
 
         // Radio Button binding special binding case:
         public bool Checked2525D
@@ -59,11 +84,30 @@ namespace ProSymbolEditor
         }
         bool _checked2525C_B2;
 
+        public bool IsSelectDBEnabled
+        {
+            get; set;
+        }
+
+        public string DefaultDatabase
+        {
+            get; set;
+        }
+
+        public bool DefaultDatabaseChanged
+        {
+            get;
+            set;
+        }
+
         public SettingsWindow()
         {
             InitializeComponent();
 
             this.DataContext = this;
+
+            this.DefaultDatabaseChanged = false;
+            this.IsSelectDBEnabled = false;
         }
 
         public void ShowDialog(Window owner)
@@ -76,5 +120,30 @@ namespace ProSymbolEditor
         {
             this.DialogResult = true;
         }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            // or give user the option of selecting workspace:
+            string selectedGDB = ProSymbolUtilities.BrowseItem(ArcGIS.Desktop.Catalog.ItemFilters.geodatabases);
+
+            if (DefaultDatabase != selectedGDB)
+            {
+                DefaultDatabaseChanged = true;
+                DefaultDatabase = selectedGDB;
+
+                RaisePropertyChanged("DefaultDatabase");
+            }
+
+        }
+
+        private void RaisePropertyChanged(string propertyName)
+        {
+            if (PropertyChanged != null)
+            {
+                PropertyChanged.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
     }
 }

--- a/source/ProSymbolEditor/SettingsWindow.xaml.cs
+++ b/source/ProSymbolEditor/SettingsWindow.xaml.cs
@@ -167,8 +167,8 @@ namespace ProSymbolEditor
                     ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(
                         "Database: " + selectedGDB + "\n" +
                         "contains a schema for standard: " +
-                        ProSymbolUtilities.GetStandardLabel(standardFound) + "\n" +
-                        "Standard setting set to this standard."
+                        ProSymbolUtilities.GetStandardLabel(standardFound) + ".\n" +
+                        "Setting standard to this value."
                         , "Database Contains Schema",
                         MessageBoxButton.OK, MessageBoxImage.Information);
 

--- a/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
+++ b/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
@@ -77,14 +77,6 @@ namespace ProSymbolEditor
             return "mil" + StandardString.ToLower();
         }
 
-        public static string GetDatasetName()
-        {
-            if (Standard == SupportedStandardsType.mil2525c_b2)
-                return "militaryoverlay2525b2";
-            else
-                return "militaryoverlay2525d";
-        }
-
         public static string NameSeparator
         {
             get { return " : "; }
@@ -392,6 +384,32 @@ namespace ProSymbolEditor
             dictionaryRenderer.FieldMap = stringMap;
 
             return dictionaryRenderer;
+        }
+
+        public static string BrowseItem(string itemFilter, string initialPath = "")
+        {
+            string itemPath = "";
+
+            if (string.IsNullOrEmpty(initialPath))
+                initialPath = ArcGIS.Desktop.Core.Project.Current.HomeFolderPath;
+
+            ArcGIS.Desktop.Catalog.OpenItemDialog pathDialog =
+                new ArcGIS.Desktop.Catalog.OpenItemDialog()
+                {
+                    Title = "Select Folder",
+                    InitialLocation = initialPath,
+                    MultiSelect = false,
+                    Filter = itemFilter,
+                };
+
+            bool? ok = pathDialog.ShowDialog();
+            if ((ok == true) && (pathDialog.Items.Count() > 0))
+            {
+                IEnumerable<ArcGIS.Desktop.Core.Item> selectedItems = pathDialog.Items;
+                itemPath = selectedItems.First().Path;
+            }
+
+            return itemPath;
         }
 
     }

--- a/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
+++ b/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
@@ -81,6 +81,14 @@ namespace ProSymbolEditor
                 return "2525B";
         }
 
+        public static string GetDatasetName(SupportedStandardsType standardIn)
+        {
+            if (standardIn == SupportedStandardsType.mil2525d)
+                return "militaryoverlay2525d";
+            else
+                return "militaryoverlay2525b2";
+        }
+
         public static string GetStandardString(SupportedStandardsType standardIn)
         {
             if (standardIn == SupportedStandardsType.mil2525c_b2)

--- a/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
+++ b/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
@@ -52,11 +52,28 @@ namespace ProSymbolEditor
         {
             get
             {
-                return GetStandardLabel(Standard);
+                return GetShortStandardLabel(Standard);
             }
         }
 
         public static string GetStandardLabel(SupportedStandardsType standardIn)
+        {
+            if (standardIn == SupportedStandardsType.mil2525d)
+                return "MIL-STD-2525D";
+            else
+                return "MIL-STD-2525B w/ Change 2";
+        }
+
+        public static SupportedStandardsType GetStandardFromLabel(string standardString)
+        {
+            if (standardString == GetStandardLabel(SupportedStandardsType.mil2525c_b2))
+                return SupportedStandardsType.mil2525c_b2;
+            else
+                return SupportedStandardsType.mil2525d;
+        }
+
+
+        public static string GetShortStandardLabel(SupportedStandardsType standardIn)
         {           
             if (standardIn == SupportedStandardsType.mil2525d)
                 return "2525D";

--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -214,9 +214,9 @@ namespace ProSymbolEditor
                 // 2. Select an existing GDB 
 
                 var result = ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(
-                    "The Military Overlay datamodel was not found in the project. \n" +
-                    "Would you like to add a layer package with the datamodel to your project?", 
-                    "Add Military Overlay Datamodel?",
+                    "The required Military Overlay datamodel was not found in the project. \n" +
+                    "Would you like to add the Military Overlay Layer Package to your project?",
+                    "Add Military Overlay Layer Package?",
                     System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxImage.Asterisk);
                 if (Convert.ToString(result) == "Yes")
                 {
@@ -226,7 +226,8 @@ namespace ProSymbolEditor
                 {
                     // See if user wants to select database to use
                     var result2 = ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(
-                        "Would you like to select a database containing the datamodel to add to the project?", 
+                        "Would you like to select a database containing the military overlay datamodel and " +
+                        "add this database the project?", 
                         "Add Database with Military Overlay Datamodel?",
                         System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxImage.Asterisk);
                     if (Convert.ToString(result2) == "Yes")
@@ -2641,9 +2642,9 @@ namespace ProSymbolEditor
             await Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, (Action)(async () =>
             {
                 string message = "The " + ProSymbolUtilities.StandardLabel +
-                    " Military Overlay schema is not detected in any database in your project," +
-                    " so the Pro Symbol Editor cannot continue." +
-                    " Would you like to add the Military Overlay Layer Package to add the schema to your project?";
+                    " Military Overlay schema is not detected in any database in your project. \n" +
+                    " so the Military Symbol Editor cannot continue." +
+                    " Would you like to add the Military Overlay Layer Package to your project?";
 
                 MessageBoxResult result = ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(message, "Add-In Disabled", MessageBoxButton.YesNo, MessageBoxImage.Exclamation);
                 if (result.ToString() == "Yes")

--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -1140,7 +1140,9 @@ namespace ProSymbolEditor
             bool enabledWithNewStandard = false;
 
             // If Settings Dialog cancelled - or read-only - return
-            if ((settingsWindow.DialogResult != true) || (isSettingsReadOnly))
+            if (isSettingsReadOnly)
+                return true;
+            if (settingsWindow.DialogResult != true)
                 return false; 
 
             ProSymbolUtilities.SupportedStandardsType newSettingStandard =
@@ -1181,20 +1183,6 @@ namespace ProSymbolEditor
 
                 if (enabledWithNewStandard)
                 {
-                    var result = ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(
-                        "Database: " + newDatabase + "\n" +
-                        "already contains a schema for standard: " +
-                        ProSymbolUtilities.GetStandardLabel(newSettingStandard) + "\n" +
-                        "Do you want to use this existing database and schema?"
-                        , "Use Existing Schema and Feature Classes?",
-                        MessageBoxButton.OKCancel, MessageBoxImage.Question);
-
-                    if (Convert.ToString(result) == "Cancel")
-                    {
-                        ProSymbolEditorModule.Current.MilitaryOverlaySchema.Reset();
-                        return false;
-                    }
-
                     StatusMessage = "Database Added";
                 }
                 else

--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -243,12 +243,15 @@ namespace ProSymbolEditor
                     "(database schema and layers to the TOC) to the project?. \n",
                     "Add-in Disabled",
                     System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxImage.Asterisk);
+
+                bool success = false;
                 if (Convert.ToString(result) == "Yes")
                 {
-                    bool success = await ShowSettingsWindowAsync(true);
-
-                    if (!success)
-                        return;
+                    success = await ShowSettingsWindowAsync(true);
+                }
+                if (!success)
+                {
+                    return;
                 }
             }
             else

--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -200,6 +200,8 @@ namespace ProSymbolEditor
 
         private async Task Initialize()
         {
+            ProSymbolEditorModule.Current.MilitaryOverlaySchema.Reset();
+
             // Somewhat tricky, see if the project has a GDB with an existing standard, if so just set to that
             bool isEnabled2525C_B2 = await ProSymbolEditorModule.Current.MilitaryOverlaySchema.ShouldAddInBeEnabledAsync(ProSymbolUtilities.SupportedStandardsType.mil2525c_b2);
 

--- a/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
+++ b/source/ProSymbolEditor/Views/MilitarySymbolDockpane.xaml
@@ -95,7 +95,7 @@
                     Grid.Row="0"
                     Margin="3,3,3,3"
                     SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                    <TabItem Header="Search">
+                    <TabItem Header="Search" IsEnabled="{Binding IsAddinEnabled}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*" />
@@ -112,6 +112,7 @@
                                         </Grid.RowDefinitions>
 
                                         <TextBox
+                                            IsEnabled="{Binding IsAddinEnabled}"
                                             x:Name="searchSymbolsTextBox"
                                             Grid.Row="0"
                                             Height="23"
@@ -298,6 +299,7 @@
                                     HorizontalAlignment="Center"
                                     Command="{Binding SaveSymbolFileCommand}"
                                     Content="Add Favorite"
+                                    IsEnabled="{Binding IsStyleItemSelected}"
                                     Style="{DynamicResource Esri_SimpleButton}" />
                                 <ToggleButton
                                     Name="searchAddToMapButton"
@@ -333,7 +335,7 @@
                             </Grid>
                         </Grid>
                     </TabItem>
-                    <TabItem Header="Modify">
+                    <TabItem Header="Modify" IsEnabled="{Binding IsAddinEnabled}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*" />
@@ -540,7 +542,7 @@
                             </Grid>
                         </Grid>
                     </TabItem>
-                    <TabItem HorizontalAlignment="Stretch" Header="Favorites">
+                    <TabItem HorizontalAlignment="Stretch" Header="Favorites" IsEnabled="{Binding IsAddinEnabled}">
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*" />


### PR DESCRIPTION
Addresses: 

#55 - User should be able to select database containing Military Overlay feature classes  
#154 - User should be prompted about which schema they intend to add to their project at the outset, not when selecting the first symbol they want to use
#116 - Refactor code to have a single list of feature classes 

For #55, and #154 - there are prompts added when the Military Overlay Addin Dockpane is first used to prompt:

On Start:

1. No datamodel found in project, prompt to add:

![form-adddatamodel](https://user-images.githubusercontent.com/3090809/44665286-85aa4900-a9e3-11e8-9f49-2e2209c4eb34.PNG)

2. If "No" - prompt for database:

![form-selectdatabase](https://user-images.githubusercontent.com/3090809/44665303-8e9b1a80-a9e3-11e8-8fe2-1e91efd61dda.PNG)

3. If "Yes" bring up settings form that allows the database to be selected:

![form-setdatabase](https://user-images.githubusercontent.com/3090809/44665319-978bec00-a9e3-11e8-94d7-041f90c145c0.PNG)

