### PR TITLE
Delivery for Military Tools Desktop Addins - Sprint 1 of 1

### DIFF
--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -1356,7 +1356,20 @@ namespace ProSymbolEditor
                                 var task = editOperation.ExecuteAsync();
                                 modificationResult = task.Result;
                                 if (!modificationResult)
+                                {
                                     message = editOperation.ErrorMessage;
+                                    QueuedTask.Run(async () =>
+                                    {
+                                        await Project.Current.DiscardEditsAsync();
+                                    });
+                                }
+                                else
+                                {
+                                    QueuedTask.Run(async () =>
+                                    {
+                                        await Project.Current.SaveEditsAsync();
+                                    });
+                                }
                             }
                         }
                     }
@@ -1542,7 +1555,12 @@ namespace ProSymbolEditor
 
                                 if (!creationResult)
                                 {
-                                    message = editOperation.ErrorMessage;
+                                    ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(message);
+                                    await Project.Current.DiscardEditsAsync();
+                                }
+                                else
+                                {
+                                    await Project.Current.SaveEditsAsync();
                                 }
 
                                 break;


### PR DESCRIPTION
This release addresses below mentioned issue
Military tools issue [67](https://github.com/Esri/military-tools-desktop-addins/issues/67) - Default Geodatabase locks happening when working across component addins