### PR TITLE
Issue #323 METOC symbols (and others) missing from search

### DIFF
--- a/source/ProSymbolEditor/Models/SymbolAttributes/DisplayAttributes.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/DisplayAttributes.cs
@@ -14,14 +14,13 @@
  *   limitations under the License.
  ******************************************************************************/
 
-using ArcGIS.Desktop.Framework.Contracts;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Web.Script.Serialization;
+
+using ArcGIS.Core.Geometry;
+using ArcGIS.Desktop.Framework.Contracts;
 
 namespace ProSymbolEditor
 {
@@ -132,6 +131,8 @@ namespace ProSymbolEditor
         private string _extendedFunctionCode;
         private DomainCodedValuePair _selectedExtendedFunctionCodeDomainPair;
 
+        public GeometryType SymbolGeometry { get; set; }
+
         public string LegacySymbolIdCode
         {
             get
@@ -142,30 +143,51 @@ namespace ProSymbolEditor
                 if ((ProSymbolUtilities.Standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
                     && (!String.IsNullOrEmpty(extendedFunctionCode)) && (extendedFunctionCode.Length >= 10))
                 {
-                    sb.Append(extendedFunctionCode[0]);
-                    // TODO: Check for Alpha
-                    if (String.IsNullOrEmpty(Identity))
-                        sb.Append('U');
-                    else
-                        sb.Append(Identity);
-                    sb.Append(extendedFunctionCode[2]);
+                    bool isWeather = (extendedFunctionCode[0] == 'W');
 
-                    // TODO: Check for Alpha
-                    if (String.IsNullOrEmpty(Status))
-                        sb.Append('P');
+                    if (isWeather)
+                    {
+                        sb.Append(extendedFunctionCode.Substring(0, 10));
+
+                        switch (this.SymbolGeometry)
+                        {
+                            case GeometryType.Point: sb.Append("P--"); break;
+                            case GeometryType.Polyline: sb.Append("-L-"); break;
+                            case GeometryType.Polygon: sb.Append("--A"); break;
+                            default: sb.Append("---"); break;
+                        }
+
+                        sb.Append("--");
+                    }
                     else
-                        sb.Append(Status);
-                    sb.Append(extendedFunctionCode.Substring(4, 6));
-                    // TODO: Check for Alpha
-                    if (String.IsNullOrEmpty(Indicator))
-                        sb.Append('-');
-                    else
-                        sb.Append(Indicator);
-                    if (String.IsNullOrEmpty(Echelon))
-                        sb.Append('-');
-                    else
-                        sb.Append(Echelon);
-                    sb.Append("---");
+                    {
+                        sb.Append(extendedFunctionCode[0]);
+                        if (String.IsNullOrEmpty(Identity))
+                            sb.Append('U');
+                        else
+                            sb.Append(Identity);
+
+                        sb.Append(extendedFunctionCode[2]);
+
+                        if (String.IsNullOrEmpty(Status))
+                            sb.Append('P');
+                        else
+                            sb.Append(Status);
+
+                        sb.Append(extendedFunctionCode.Substring(4, 6));
+
+                        if (String.IsNullOrEmpty(Indicator))
+                            sb.Append('-');
+                        else
+                            sb.Append(Indicator);
+
+                        if (String.IsNullOrEmpty(Echelon))
+                            sb.Append('-');
+                        else
+                            sb.Append(Echelon);
+
+                        sb.Append("---");
+                    }
                 }
 
                 return sb.ToString();

--- a/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
@@ -289,7 +289,7 @@ namespace ProSymbolEditor
             // Don't create preview until we have the minimum number of attributes in
             // order to minimize flicker - minimum attributes:
             // 2525D: { symbolset, entity, affiliation }
-            // 2525B: { functioncode, affiliation }
+            // 2525B: { extendedfunctioncode, affiliation }
             int minimumAttributeCount = 4;
             if (ProSymbolUtilities.Standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
             {
@@ -298,9 +298,13 @@ namespace ProSymbolEditor
 
             if (attributeSet.ContainsKey("IsMETOC") && (bool)attributeSet["IsMETOC"])
             {
-                if (attributeSet.ContainsKey("extendedfunctioncode"))
+                //////////////////////////
+                // WORKAROUND: Pro 2.3 broke exporting METOC by attribute "extendedfunctioncode"
+                // so have to set "sidc" attribute instead
+                if (ProSymbolUtilities.IsNewStyleFormat && attributeSet.ContainsKey("extendedfunctioncode"))
                     attributeSet.Add("sidc", DisplayAttributes.LegacySymbolIdCode);
-                // METOC do not have identity/affiliation 
+
+                // METOC do not have identity/affiliation so have 1 less attribute
                 minimumAttributeCount--;
             }
 

--- a/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
@@ -17,10 +17,12 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Media.Imaging;
-using ArcGIS.Core.Data;
-using ArcGIS.Desktop.Framework.Contracts;
 using System.Web.Script.Serialization;
 using System.ComponentModel;
+
+using ArcGIS.Core.Data;
+using ArcGIS.Desktop.Framework.Contracts;
+
 using Xceed.Wpf.Toolkit.PropertyGrid.Attributes;
 
 namespace ProSymbolEditor
@@ -288,10 +290,18 @@ namespace ProSymbolEditor
             // order to minimize flicker - minimum attributes:
             // 2525D: { symbolset, entity, affiliation }
             // 2525B: { functioncode, affiliation }
-            int minimumAttributeCount = 3;
+            int minimumAttributeCount = 4;
             if (ProSymbolUtilities.Standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
             {
-                minimumAttributeCount = 2;
+                minimumAttributeCount = 3;
+            }
+
+            if (attributeSet.ContainsKey("IsMETOC") && (bool)attributeSet["IsMETOC"])
+            {
+                if (attributeSet.ContainsKey("extendedfunctioncode"))
+                    attributeSet.Add("sidc", DisplayAttributes.LegacySymbolIdCode);
+                // METOC do not have identity/affiliation 
+                minimumAttributeCount--;
             }
 
             // Validate that image is ready to be created
@@ -310,11 +320,15 @@ namespace ProSymbolEditor
         {
             Dictionary<string, object> attributeSet = new Dictionary<string, object>();
 
+            bool isMETOC = false;
             if (ProSymbolUtilities.Standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
             {
                 if (!string.IsNullOrEmpty(DisplayAttributes.ExtendedFunctionCode))
                 {
                     attributeSet["extendedfunctioncode"] = DisplayAttributes.ExtendedFunctionCode;
+
+                    if (DisplayAttributes.ExtendedFunctionCode[0] == 'W')
+                        isMETOC = true;
                 }
 
                 if (!string.IsNullOrEmpty(DisplayAttributes.Identity))
@@ -347,6 +361,10 @@ namespace ProSymbolEditor
                 if (!string.IsNullOrEmpty(DisplayAttributes.SymbolSet))
                 {
                     attributeSet["symbolset"] = DisplayAttributes.SymbolSet;
+
+                    if ((DisplayAttributes.SymbolSet == "45") ||
+                        (DisplayAttributes.SymbolSet == "46"))
+                        isMETOC = true;
                 }
 
                 if (!string.IsNullOrEmpty(DisplayAttributes.SymbolEntity))
@@ -399,6 +417,8 @@ namespace ProSymbolEditor
                     attributeSet["modifier2"] = DisplayAttributes.Modifier2;
                 }
             }
+
+            attributeSet.Add("IsMETOC", isMETOC);
 
             return attributeSet;
         }

--- a/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
+++ b/source/ProSymbolEditor/Utilities/ProSymbolUtilities.cs
@@ -133,6 +133,16 @@ namespace ProSymbolEditor
                                       new Uri(asm.CodeBase).LocalPath));
         }
 
+        public static bool IsNewStyleFormat
+        {
+            get
+            {
+                bool newStyleFormat = ((ProSymbolUtilities.ProMajorVersion >= 2) && (ProSymbolUtilities.ProMinorVersion >= 3));
+
+                return newStyleFormat;
+            }
+        }
+
         public static CoordinateType GetCoordinateType(string input, out MapPoint point)
         {
             point = null;

--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -221,7 +221,8 @@ namespace ProSymbolEditor
             // re-load the favorites
             foreach (SymbolAttributeSet set in Favorites)
             {
-                set.GeneratePreviewSymbol();
+                if (set.StandardVersion == ProSymbolUtilities.StandardString)
+                    set.GeneratePreviewSymbol();
             }
 
             _favoritesView.Refresh();
@@ -2816,7 +2817,8 @@ namespace ProSymbolEditor
             //Go through favorites, generate symbol image
             foreach (SymbolAttributeSet set in Favorites)
             {
-                set.GeneratePreviewSymbol();
+                if (set.StandardVersion == ProSymbolUtilities.StandardString)
+                    set.GeneratePreviewSymbol();
             }
 
             //Set up filter

--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -1814,6 +1814,7 @@ namespace ProSymbolEditor
                 //Get feature class name to generate domains
                 SymbolAttributeSet.DisplayAttributes.SymbolSet = loadSet.DisplayAttributes.SymbolSet;
                 SymbolAttributeSet.DisplayAttributes.SymbolEntity = loadSet.DisplayAttributes.SymbolEntity;
+                SymbolAttributeSet.DisplayAttributes.SymbolGeometry = GeometryType;
 
                 SymbolAttributeSet.DisplayAttributes.ExtendedFunctionCode = loadSet.DisplayAttributes.ExtendedFunctionCode;
 
@@ -2689,10 +2690,19 @@ namespace ProSymbolEditor
 
             int lastSemicolon = tags.LastIndexOf(';');
             string symbolIdCode = tags.Substring(lastSemicolon + 1, tags.Length - lastSemicolon - 1);
-            symbolId[0] = string.Format("{0}{1}", symbolIdCode[0], symbolIdCode[1]);
-            symbolId[1] = string.Format("{0}{1}{2}{3}{4}{5}", symbolIdCode[2], symbolIdCode[3], symbolIdCode[4], symbolIdCode[5], symbolIdCode[6], symbolIdCode[7]);
 
-            if (ProSymbolUtilities.Standard == ProSymbolUtilities.SupportedStandardsType.mil2525d)
+            if (string.IsNullOrEmpty(symbolIdCode) || (symbolIdCode.Length < 8))
+            {
+                symbolId[0] = String.Empty;
+                symbolId[1] = String.Empty;
+            }
+            else
+            {
+                symbolId[0] = string.Format("{0}{1}", symbolIdCode[0], symbolIdCode[1]);
+                symbolId[1] = string.Format("{0}{1}{2}{3}{4}{5}", symbolIdCode[2], symbolIdCode[3], symbolIdCode[4], symbolIdCode[5], symbolIdCode[6], symbolIdCode[7]);
+            }
+
+            if (ProSymbolUtilities.Standard != ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
             {
                 symbolId[2] = String.Empty;
             }


### PR DESCRIPTION
Issue #323 METOC symbols (and others) missing from search

Also in new style format, the SIDC had moved from tags to key field.