### PR TITLE
Issue #222 - allow user to change entity field/attribute for 2525D

### DIFF
--- a/source/ProSymbolEditor/Models/MilitaryFieldsInspectorModel.cs
+++ b/source/ProSymbolEditor/Models/MilitaryFieldsInspectorModel.cs
@@ -56,6 +56,7 @@ namespace ProSymbolEditor
         public ObservableCollection<DomainCodedValuePair> Modifier2DomainValues { get; set; }
         public ObservableCollection<DomainCodedValuePair> CountryCodeDomainValues { get; set; }
         public ObservableCollection<DomainCodedValuePair> ExtendedFunctionCodeValues { get; set; }
+        public ObservableCollection<DomainCodedValuePair> EntityCodeValues { get; set; }
 
         public Visibility DateTimeValidFieldExists
         {
@@ -189,6 +190,7 @@ namespace ProSymbolEditor
             MobilityDomainValues = new ObservableCollection<DomainCodedValuePair>();
             TfFdHqDomainValues = new ObservableCollection<DomainCodedValuePair>();
             ContextDomainValues = new ObservableCollection<DomainCodedValuePair>();
+            EntityCodeValues = new ObservableCollection<DomainCodedValuePair>();
             Modifier1DomainValues = new ObservableCollection<DomainCodedValuePair>();
             Modifier2DomainValues = new ObservableCollection<DomainCodedValuePair>();
             CountryCodeDomainValues = new ObservableCollection<DomainCodedValuePair>();
@@ -262,6 +264,7 @@ namespace ProSymbolEditor
 
             if (ProSymbolUtilities.Standard == ProSymbolUtilities.SupportedStandardsType.mil2525c_b2)
             {
+                EntityCodeValues.Clear();
                 GetDomainAndPopulateList(fields, "affiliation", IdentityDomainValues);
                 GetDomainAndPopulateList(fields, "echelonmobility", EchelonDomainValues);
                 GetDomainAndPopulateList(fields, "extendedfunctioncode", ExtendedFunctionCodeValues);
@@ -279,6 +282,7 @@ namespace ProSymbolEditor
             GetDomainAndPopulateList(fields, "operationalcondition", OperationalConditionAmplifierDomainValues);
             GetDomainAndPopulateList(fields, "mobility", MobilityDomainValues);
             GetDomainAndPopulateList(fields, "context", ContextDomainValues);
+            GetDomainAndPopulateList(fields, "symbolentity", EntityCodeValues);
             GetDomainAndPopulateList(fields, "modifier1", Modifier1DomainValues);
             GetDomainAndPopulateList(fields, "modifier2", Modifier2DomainValues);
             GetDomainAndPopulateList(fields, "countrycode", CountryCodeDomainValues, true);

--- a/source/ProSymbolEditor/Models/SymbolAttributes/DisplayAttributes.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/DisplayAttributes.cs
@@ -110,6 +110,7 @@ namespace ProSymbolEditor
         //Base attributes
         private string _symbolSet;
         private string _symbolEntity;
+        private DomainCodedValuePair _selectedEntityCodeDomainPair;
         private string _identity;
         private DomainCodedValuePair _selectedIdentityDomainPair;
         private string _status;
@@ -226,6 +227,28 @@ namespace ProSymbolEditor
                 else
                 {
                     _extendedFunctionCode = "";
+                }
+            }
+        }
+
+        [ScriptIgnore, Browsable(false)]
+        public DomainCodedValuePair SelectedEntityCodeDomainPair
+        {
+            get
+            {
+                return _selectedEntityCodeDomainPair;
+            }
+            set
+            {
+                _selectedEntityCodeDomainPair = value;
+                if (_selectedEntityCodeDomainPair != null)
+                {
+                    _symbolEntity = _selectedEntityCodeDomainPair.Code.ToString();
+                    NotifyPropertyChanged(() => SelectedEntityCodeDomainPair);
+                }
+                else
+                {
+                    _symbolEntity = "";
                 }
             }
         }

--- a/source/ProSymbolEditor/Views/SymbolView.xaml
+++ b/source/ProSymbolEditor/Views/SymbolView.xaml
@@ -38,6 +38,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
                     <Grid.ColumnDefinitions>
@@ -107,7 +108,7 @@
                                             Grid.Row="2"
                                             Grid.Column="0"
                                             Margin="5,5,5,5"
-                                            Content="Operational Condition Amplifier"
+                                            Content="Operational Condition"
                                             Visibility="{Binding ElementName=operationalConditionAmplifierComboBox, Path=Visibility}" />
                     <ComboBox
                                             x:Name="operationalConditionAmplifierComboBox"
@@ -291,6 +292,35 @@
                                             ItemsSource="{Binding MilitaryFieldsInspectorModel.Modifier2DomainValues}"
                                             SelectedItem="{Binding SymbolAttributeSet.DisplayAttributes.SelectedModifier2DomainPair, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                             SelectedValuePath="Code">
+                        <ComboBox.Style>
+                            <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+                                <Style.Triggers>
+                                    <Trigger Property="HasItems" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ComboBox.Style>
+                    </ComboBox>
+
+                    <!--  Entity Code (2525D Only)  -->
+                    <Label
+                        Grid.Row="10"
+                        Grid.Column="0"
+                        Margin="5,5,5,5"
+                        Content="Entity"
+                        Visibility="{Binding ElementName=entityCodeComboBox, Path=Visibility}" />
+                    <ComboBox
+                                            x:Name="entityCodeComboBox"
+                                            Grid.Row="10"
+                                            Grid.Column="1"
+                                            Margin="5,5,5,5"
+                                            DisplayMemberPath="Name"
+                                            ItemContainerStyle="{DynamicResource Esri_HighlightListBoxItem}"
+                                            ItemsSource="{Binding MilitaryFieldsInspectorModel.EntityCodeValues}"
+                                            SelectedItem="{Binding SymbolAttributeSet.DisplayAttributes.SelectedEntityCodeDomainPair, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                            SelectedValuePath="Code"
+                                            ToolTip="{Binding Path=SelectedItem.Name, RelativeSource={RelativeSource Self}}">
                         <ComboBox.Style>
                             <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
                                 <Style.Triggers>


### PR DESCRIPTION
Address Issue #222 also address some other behavior noted in https://github.com/Esri/military-symbology/issues/222#issuecomment-463716920.

Adds ability to set/change the Entity from the symbol tab:

![image](https://user-images.githubusercontent.com/3090809/52722828-6a73cb80-2f7a-11e9-845b-6bd81b702ef8.png)
