### PR TITLE
Add newly supported labels to MSE addin

### DIFF
--- a/source/ProSymbolEditor/Controls/NumberUpDownControl.xaml.cs
+++ b/source/ProSymbolEditor/Controls/NumberUpDownControl.xaml.cs
@@ -55,6 +55,12 @@ namespace ProSymbolEditor.Controls
                 numberUpDownControl.NumberUpDownControlTextBox.Text = String.Empty;
                 numberUpDownControl._ignoreTextUpdate = false;
             }
+            else
+            {
+                numberUpDownControl._ignoreTextUpdate = true;
+                numberUpDownControl.NumberUpDownControlTextBox.Text = e.NewValue.ToString();
+                numberUpDownControl._ignoreTextUpdate = false;
+            }
         }
 
         public short? CurrentValue

--- a/source/ProSymbolEditor/Models/SymbolAttributes/LabelAttributes.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/LabelAttributes.cs
@@ -35,6 +35,7 @@ namespace ProSymbolEditor
         private string _type;
         private string _commonidentifier;
         private short? _speed;
+        private short? _direction;
         private string _higherFormation;
         private string _reinforced;
         private DomainCodedValuePair _selectedReinforcedDomainPair;
@@ -42,6 +43,8 @@ namespace ProSymbolEditor
         private DomainCodedValuePair _selectedCredibilityDomainPair;
         private string _reliability;
         private DomainCodedValuePair _selectedReliabilityDomainPair;
+        private string _signatureEquipment;
+        private DomainCodedValuePair _selectedSignatureEquipmentDomainPair;
         private string _countryCode;
         private DomainCodedValuePair _selectedCountryCodeDomainPair;
         private string lengthError = "The label entered is at the maximum allowable length for this feature field";
@@ -117,6 +120,7 @@ namespace ProSymbolEditor
                 hashcode = (hashcode * PRIME) ^ (_type != null ? _type.GetHashCode() : 0);
                 hashcode = (hashcode * PRIME) ^ (_commonidentifier != null ? _commonidentifier.GetHashCode() : 0);
                 hashcode = (hashcode * PRIME) ^ (_speed != null ? _speed.GetHashCode() : 0);
+                hashcode = (hashcode * PRIME) ^ (_direction != null ? _direction.GetHashCode() : 0);
                 hashcode = (hashcode * PRIME) ^ (_higherFormation != null ? _higherFormation.GetHashCode() : 0);
                 hashcode = (hashcode * PRIME) ^ (_reinforced != null ? _reinforced.GetHashCode() : 0);
                 hashcode = (hashcode * PRIME) ^ (_credibility != null ? _credibility.GetHashCode() : 0);
@@ -259,6 +263,19 @@ namespace ProSymbolEditor
             }
         }
 
+        public short? Direction
+        {
+            get
+            {
+                return _direction;
+            }
+            set
+            {
+                _direction = value;
+                NotifyPropertyChanged(() => Direction);
+            }
+        }
+
         public string HigherFormation
         {
             get
@@ -382,6 +399,43 @@ namespace ProSymbolEditor
             }
         }
 
+        public string SignatureEquipment
+        {
+            get
+            {
+                return _signatureEquipment;
+            }
+            set
+            {
+                _signatureEquipment = value;
+                NotifyPropertyChanged(() => SignatureEquipment);
+            }
+        }
+
+        [ScriptIgnore, Browsable(false)]
+        public DomainCodedValuePair SelectedSignatureEquipmentDomainPair
+        {
+            get
+            {
+                return _selectedSignatureEquipmentDomainPair;
+            }
+            set
+            {
+                _selectedSignatureEquipmentDomainPair = value;
+                if (_selectedSignatureEquipmentDomainPair != null)
+                {
+                    SignatureEquipment = _selectedSignatureEquipmentDomainPair.Code.ToString();
+                }
+                else
+                {
+                    SignatureEquipment = "";
+                }
+                NotifyPropertyChanged(() => SelectedSignatureEquipmentDomainPair);
+            }
+        }
+
+        public string CountryLabel { get; set; }
+
         public string CountryCode
         {
             get
@@ -408,10 +462,12 @@ namespace ProSymbolEditor
                 if (_selectedCountryCodeDomainPair != null)
                 {
                     CountryCode = _selectedCountryCodeDomainPair.Code.ToString();
+                    CountryLabel = _selectedCountryCodeDomainPair.Name;
                 }
                 else
                 {
                     CountryCode = "";
+                    CountryLabel = "";
                 }
                 NotifyPropertyChanged(() => SelectedCountryCodeDomainPair);
             }

--- a/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
@@ -636,7 +636,9 @@ namespace ProSymbolEditor
                 (LabelAttributes.CountryCode != ProSymbolUtilities.NullFieldValueFlag))
             {
                 rowBuffer["countrycode"] = LabelAttributes.CountryCode;
-                rowBuffer["countrylabel"] = LabelAttributes.CountryLabel;
+
+                if (rowBuffer.FindField("countrylabel") >= 0) // does not exist in all versions of the database
+                    rowBuffer["countrylabel"] = LabelAttributes.CountryLabel;
             }
 
         }

--- a/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
+++ b/source/ProSymbolEditor/Models/SymbolAttributes/SymbolAttributeSet.cs
@@ -597,6 +597,12 @@ namespace ProSymbolEditor
                 rowBuffer["speed"] = LabelAttributes.Speed;
             }
 
+            if (LabelAttributes.Direction != null)
+            {
+                //Short
+                rowBuffer["direction"] = LabelAttributes.Direction;
+            }
+
             if (!string.IsNullOrEmpty(LabelAttributes.HigherFormation))
             {
                 rowBuffer["higherFormation"] = LabelAttributes.HigherFormation;
@@ -620,11 +626,19 @@ namespace ProSymbolEditor
                 rowBuffer["reliability"] = LabelAttributes.Reliability;
             }
 
+            if (!string.IsNullOrEmpty(LabelAttributes.SignatureEquipment) &&
+                (LabelAttributes.SignatureEquipment != ProSymbolUtilities.NullFieldValueFlag))
+            {
+                rowBuffer["signatureequipment"] = LabelAttributes.SignatureEquipment;
+            }
+
             if (!string.IsNullOrEmpty(LabelAttributes.CountryCode) &&
                 (LabelAttributes.CountryCode != ProSymbolUtilities.NullFieldValueFlag))
             {
                 rowBuffer["countrycode"] = LabelAttributes.CountryCode;
+                rowBuffer["countrylabel"] = LabelAttributes.CountryLabel;
             }
+
         }
 
         public void PopulateFeatureWithAttributes(ref Feature feature)
@@ -816,6 +830,9 @@ namespace ProSymbolEditor
             if (feature.FindField("speed") >= 0)
                 feature["speed"] = LabelAttributes.Speed;
 
+            if (feature.FindField("direction") >= 0)
+                feature["direction"] = LabelAttributes.Direction;
+
             if (feature.FindField("higherFormation") >= 0)
                 feature["higherFormation"] = LabelAttributes.HigherFormation;
 
@@ -846,6 +863,15 @@ namespace ProSymbolEditor
                     feature["reliability"] = LabelAttributes.Reliability;
             }
 
+            if (!string.IsNullOrEmpty(LabelAttributes.SignatureEquipment) &&
+                (feature.FindField("signatureequipment") >= 0))
+            {
+                if (LabelAttributes.SignatureEquipment == ProSymbolUtilities.NullFieldValueFlag)
+                    feature["signatureequipment"] = null;
+                else
+                    feature["signatureequipment"] = LabelAttributes.SignatureEquipment;
+            }
+
             if (!string.IsNullOrEmpty(LabelAttributes.CountryCode) &&
                 (feature.FindField("countrycode") >= 0))
             {
@@ -854,6 +880,13 @@ namespace ProSymbolEditor
                 else
                     feature["countrycode"] = LabelAttributes.CountryCode;
             }
+
+            if (!string.IsNullOrEmpty(LabelAttributes.CountryLabel) &&
+                (feature.FindField("countrylabel") >= 0))
+            {
+                feature["countrylabel"] = LabelAttributes.CountryLabel;
+            }
+
         }
 
         private void SetPropertiesFromFieldAttributes(Dictionary<string, string> fieldValues)
@@ -988,6 +1021,11 @@ namespace ProSymbolEditor
                 LabelAttributes.Speed = short.Parse(fieldValues["speed"]);
             }
 
+            if (fieldValues.ContainsKey("direction"))
+            {
+                LabelAttributes.Direction = short.Parse(fieldValues["direction"]);
+            }
+
             if (fieldValues.ContainsKey("higherFormation"))
             {
                 LabelAttributes.HigherFormation = fieldValues["higherFormation"];
@@ -1006,6 +1044,11 @@ namespace ProSymbolEditor
             if (fieldValues.ContainsKey("reliability"))
             {
                 LabelAttributes.Reliability = fieldValues["reliability"];
+            }
+
+            if (fieldValues.ContainsKey("signatureequipment"))
+            {
+                LabelAttributes.SignatureEquipment = fieldValues["signatureequipment"];
             }
 
             if (fieldValues.ContainsKey("countrycode"))
@@ -1046,11 +1089,14 @@ namespace ProSymbolEditor
             LabelAttributes.Type = "";
             LabelAttributes.CommonIdentifier = "";
             LabelAttributes.Speed = null;
+            LabelAttributes.Direction = null;
             LabelAttributes.HigherFormation = "";
             LabelAttributes.Reinforced = "";
             LabelAttributes.Credibility = null;
             LabelAttributes.Reliability = "";
+            LabelAttributes.SignatureEquipment = "";
             LabelAttributes.CountryCode = "";
+            LabelAttributes.CountryLabel = "";
 
             SymbolTags = "";
 

--- a/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
+++ b/source/ProSymbolEditor/ViewModels/MilitarySymbolDockpaneViewModel.cs
@@ -332,6 +332,7 @@ namespace ProSymbolEditor
             BindingOperations.EnableCollectionSynchronization(MilitaryFieldsInspectorModel.ReinforcedDomainValues, _lock);
             BindingOperations.EnableCollectionSynchronization(MilitaryFieldsInspectorModel.ReliabilityDomainValues, _lock);
             BindingOperations.EnableCollectionSynchronization(MilitaryFieldsInspectorModel.CredibilityDomainValues, _lock);
+            BindingOperations.EnableCollectionSynchronization(MilitaryFieldsInspectorModel.SignatureEquipmentDomainValues, _lock);
             BindingOperations.EnableCollectionSynchronization(MilitaryFieldsInspectorModel.CountryCodeDomainValues, _lock);
             BindingOperations.EnableCollectionSynchronization(MilitaryFieldsInspectorModel.ExtendedFunctionCodeValues, _lock);
             BindingOperations.EnableCollectionSynchronization(MilitaryFieldsInspectorModel.EntityCodeValues, _lock);
@@ -1828,6 +1829,7 @@ namespace ProSymbolEditor
                 SymbolAttributeSet.LabelAttributes.Type = loadSet.LabelAttributes.Type;
                 SymbolAttributeSet.LabelAttributes.CommonIdentifier = loadSet.LabelAttributes.CommonIdentifier;
                 SymbolAttributeSet.LabelAttributes.Speed = loadSet.LabelAttributes.Speed;
+                SymbolAttributeSet.LabelAttributes.Direction = loadSet.LabelAttributes.Direction;
                 SymbolAttributeSet.LabelAttributes.UniqueDesignation = loadSet.LabelAttributes.UniqueDesignation;
                 SymbolAttributeSet.LabelAttributes.StaffComments = loadSet.LabelAttributes.StaffComments;
                 SymbolAttributeSet.LabelAttributes.AdditionalInformation = loadSet.LabelAttributes.AdditionalInformation;
@@ -2577,7 +2579,11 @@ namespace ProSymbolEditor
                         SymbolAttributeSet.LabelAttributes.SelectedReliabilityDomainPair = 
                             MilitaryFieldsInspectorModel.ReliabilityDomainValues.FirstOrDefault(pair => pair.Code.ToString() == loadSet.LabelAttributes.Reliability);
 
-                    if (loadSet.LabelAttributes.SelectedCountryCodeDomainPair != null)
+                    if (loadSet.LabelAttributes.SignatureEquipment != null)
+                        SymbolAttributeSet.LabelAttributes.SelectedSignatureEquipmentDomainPair =
+                            MilitaryFieldsInspectorModel.SignatureEquipmentDomainValues.FirstOrDefault(pair => pair.Code.ToString() == loadSet.LabelAttributes.SignatureEquipment);
+
+                    if (loadSet.LabelAttributes.CountryCode != null)
                         SymbolAttributeSet.LabelAttributes.SelectedCountryCodeDomainPair = 
                             MilitaryFieldsInspectorModel.CountryCodeDomainValues.FirstOrDefault(pair => pair.Code.ToString() == loadSet.LabelAttributes.CountryCode);
                 }

--- a/source/ProSymbolEditor/Views/LabelView.xaml
+++ b/source/ProSymbolEditor/Views/LabelView.xaml
@@ -35,20 +35,23 @@
                     </Grid.ColumnDefinitions>
 
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" /> <!-- 1 -->
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" /> <!-- 5 -->
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" /> <!-- 10 -->
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" /> <!-- 15 -->
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />                        
                     </Grid.RowDefinitions>
 
                     <Label
@@ -127,15 +130,32 @@
                         BorderBrush="{DynamicResource Esri_BorderBrush}"                                            
                         Visibility="{Binding MilitaryFieldsInspectorModel.SpeedFieldExists}"
                         CurrentValue="{Binding SymbolAttributeSet.LabelAttributes.Speed, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                        
+
                     <Label
                                             Grid.Row="6"
+                                            Grid.Column="0"
+                                            Margin="3,3,3,3"
+                                            Content="Direction"
+                                            Visibility="{Binding MilitaryFieldsInspectorModel.DirectionFieldExists}" />
+                    <mtcontrols:NumberUpDownControl 
+                        x:Name="directionUpDown"
+                        Grid.Row="6"
+                        Grid.Column="1"
+                        Margin="3,3,3,3"
+                        Foreground="{DynamicResource Esri_TextControlBrush}" 
+                        Background="{DynamicResource Esri_ControlBackgroundBrush}" 
+                        BorderBrush="{DynamicResource Esri_BorderBrush}"                                            
+                        Visibility="{Binding MilitaryFieldsInspectorModel.DirectionFieldExists}"
+                        CurrentValue="{Binding SymbolAttributeSet.LabelAttributes.Direction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                    <Label
+                                            Grid.Row="7"
                                             Grid.Column="0"
                                             Margin="3,3,3,3"
                                             Content="Unique Designation"
                                             Visibility="{Binding MilitaryFieldsInspectorModel.UniqueDesignationFieldExists}" />
                     <TextBox
-                                            Grid.Row="6"
+                                            Grid.Row="7"
                                             Grid.Column="1"
                                             Margin="3,3,3,3"
                                             Text="{Binding SymbolAttributeSet.LabelAttributes.UniqueDesignation, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}"
@@ -143,14 +163,14 @@
                                             MaxLength="{Binding SymbolAttributeSet.LabelAttributes.MaxLen30, Mode=OneWay}" />
 
                     <Label
-                                            Grid.Row="7"
+                                            Grid.Row="8"
                                             Grid.Column="0"
                                             Margin="3,3,3,3"
                                             Content="Reinforced"
                                             Visibility="{Binding ElementName=reinforcedComboBox, Path=Visibility}" />
                     <ComboBox
                                             Name="reinforcedComboBox"
-                                            Grid.Row="7"
+                                            Grid.Row="8"
                                             Grid.Column="1"
                                             Margin="3,3,3,3"
                                             DisplayMemberPath="Name"
@@ -170,13 +190,13 @@
                     </ComboBox>
 
                     <Label
-                                            Grid.Row="8"
+                                            Grid.Row="9"
                                             Grid.Column="0"
                                             Margin="3,3,3,3"
                                             Content="Staff Comments"
                                             Visibility="{Binding MilitaryFieldsInspectorModel.StaffCommentsFieldExists}" />
                     <TextBox
-                                            Grid.Row="8"
+                                            Grid.Row="9"
                                             Grid.Column="1"
                                             Margin="3,3,3,3"
                                             Text="{Binding SymbolAttributeSet.LabelAttributes.StaffComments, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}"
@@ -184,13 +204,13 @@
                                             MaxLength="{Binding SymbolAttributeSet.LabelAttributes.MaxLen20, Mode=OneWay}"/>
 
                     <Label
-                                            Grid.Row="9"
+                                            Grid.Row="10"
                                             Grid.Column="0"
                                             Margin="3,3,3,3"
                                             Content="Additional Information"
                                             Visibility="{Binding MilitaryFieldsInspectorModel.AdditionalInformationFieldExists}" />
                     <TextBox
-                                            Grid.Row="9"
+                                            Grid.Row="10"
                                             Grid.Column="1"
                                             Margin="3,3,3,3"
                                             Text="{Binding SymbolAttributeSet.LabelAttributes.AdditionalInformation, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}"
@@ -198,13 +218,13 @@
                                             MaxLength="{Binding SymbolAttributeSet.LabelAttributes.MaxLen20, Mode=OneWay}"/>
 
                     <Label
-                                            Grid.Row="10"
+                                            Grid.Row="11"
                                             Grid.Column="0"
                                             Margin="3,3,3,3"
                                             Content="Higher Formation"
                                             Visibility="{Binding MilitaryFieldsInspectorModel.HigherFormationFieldExists}" />
                     <TextBox
-                                            Grid.Row="10"
+                                            Grid.Row="11"
                                             Grid.Column="1"
                                             Margin="3,3,3,3"
                                             Text="{Binding SymbolAttributeSet.LabelAttributes.HigherFormation, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}"
@@ -212,14 +232,14 @@
                                             MaxLength="{Binding SymbolAttributeSet.LabelAttributes.MaxLen21, Mode=OneWay}"/>
 
                     <Label
-                                            Grid.Row="11"
+                                            Grid.Row="12"
                                             Grid.Column="0"
                                             Margin="3,3,3,3"
                                             Content="Credibility"
                                             Visibility="{Binding ElementName=credibilityComboBox, Path=Visibility}" />
                     <ComboBox
                                             Name="credibilityComboBox"
-                                            Grid.Row="11"
+                                            Grid.Row="12"
                                             Grid.Column="1"
                                             Margin="3,3,3,3"
                                             DisplayMemberPath="Name"
@@ -239,14 +259,14 @@
                     </ComboBox>
 
                     <Label
-                                            Grid.Row="12"
+                                            Grid.Row="13"
                                             Grid.Column="0"
                                             Margin="3,3,3,3"
                                             Content="Reliability"
                                             Visibility="{Binding ElementName=reliabilityComboBox, Path=Visibility}" />
                     <ComboBox
                                             Name="reliabilityComboBox"
-                                            Grid.Row="12"
+                                            Grid.Row="13"
                                             Grid.Column="1"
                                             Margin="3,3,3,3"
                                             DisplayMemberPath="Name"
@@ -266,14 +286,41 @@
                     </ComboBox>
 
                     <Label
-                                            Grid.Row="13"
+                                            Grid.Row="14"
+                                            Grid.Column="0"
+                                            Margin="3,3,3,3"
+                                            Content="Signature Equipment(ENY)"
+                                            Visibility="{Binding ElementName=signatureEquipmentComboBox, Path=Visibility}" />
+                    <ComboBox
+                                            Name="signatureEquipmentComboBox"
+                                            Grid.Row="14"
+                                            Grid.Column="1"
+                                            Margin="3,3,3,3"
+                                            DisplayMemberPath="Name"
+                                            ItemContainerStyle="{DynamicResource Esri_HighlightListBoxItem}"
+                                            ItemsSource="{Binding MilitaryFieldsInspectorModel.SignatureEquipmentDomainValues}"
+                                            SelectedItem="{Binding SymbolAttributeSet.LabelAttributes.SelectedSignatureEquipmentDomainPair, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                            SelectedValuePath="Code">
+                        <ComboBox.Style>
+                            <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+                                <Style.Triggers>
+                                    <Trigger Property="HasItems" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ComboBox.Style>
+                    </ComboBox>                    
+                    
+                    <Label
+                                            Grid.Row="15"
                                             Grid.Column="0"
                                             Margin="3,3,3,3"
                                             Content="Country Code"
                                             Visibility="{Binding ElementName=countryComboBox, Path=Visibility}" />
                     <ComboBox
                                             Name="countryComboBox"
-                                            Grid.Row="13"
+                                            Grid.Row="15"
                                             Grid.Column="1"
                                             Margin="3,3,3,3"
                                             DisplayMemberPath="Name"


### PR DESCRIPTION
Adds:

1. Attributes for direction, signatureequipment to label tab, 
2. Also sets countrylabel attribute so that label will show up in standards/features that support (APP6B/D, and 2525D Activities)
3. Fixed a bug where up/down spinner control did not initialize correctly from favorite/map selection

Relates to #353, #354, #363
